### PR TITLE
キーワード内の`-s`がオプションと解釈される問題を修正

### DIFF
--- a/pkg/cli/soiprompt/complete/common.go
+++ b/pkg/cli/soiprompt/complete/common.go
@@ -47,7 +47,7 @@ func removeCmd(text string, commands ...string) string {
 
 func removeOption(text string) string {
 	// TODO 通常の順に並べ文字数順にソートするロジックに変更する
-	options := []string{"-p", "-c", "-f", "-s", "-n", "-a", "-v"}
+	options := []string{" -p", " -c", " -f", " -s", " -n", " -a", " -v"}
 	for _, opt := range options {
 		text = strings.ReplaceAll(text, opt, "")
 	}

--- a/pkg/cli/soiprompt/complete/common.go
+++ b/pkg/cli/soiprompt/complete/common.go
@@ -45,11 +45,24 @@ func removeCmd(text string, commands ...string) string {
 	return text
 }
 
+var listOptSuggests = []prompt.Suggest{
+	{Text: "-p", Description: "open in private mode"},
+	{Text: "-c", Description: "open w/ chrome"},
+	{Text: "-f", Description: "open w/ firefox"},
+	{Text: "-s", Description: "open w/ safari"},
+	{Text: "-n", Description: "sort by num-views"},
+	{Text: "-a", Description: "sort by add-day"},
+	{Text: "-v", Description: "sort by view-day"},
+}
+
 func removeOption(text string) string {
 	// TODO 通常の順に並べ文字数順にソートするロジックに変更する
-	options := []string{" -p", " -c", " -f", " -s", " -n", " -a", " -v"}
+	var options []string
+	for _, s := range listOptSuggests {
+		options = append(options, s.Text)
+	}
 	for _, opt := range options {
-		text = strings.ReplaceAll(text, opt, "")
+		text = strings.ReplaceAll(text, " "+opt, "")
 	}
 	return strings.TrimSpace(text)
 }

--- a/pkg/cli/soiprompt/complete/list.go
+++ b/pkg/cli/soiprompt/complete/list.go
@@ -12,13 +12,3 @@ func (c *Completer) listCmd(d prompt.Document) []prompt.Suggest {
 	}
 	return c.baseList(d, "list", "ls", "l")
 }
-
-var listOptSuggests = []prompt.Suggest{
-	{Text: "-p", Description: "open in private mode"},
-	{Text: "-c", Description: "open w/ chrome"},
-	{Text: "-f", Description: "open w/ firefox"},
-	{Text: "-s", Description: "open w/ safari"},
-	{Text: "-n", Description: "sort by num-views"},
-	{Text: "-a", Description: "sort by add-day"},
-	{Text: "-v", Description: "sort by view-day"},
-}

--- a/pkg/cli/soiprompt/utils/option.go
+++ b/pkg/cli/soiprompt/utils/option.go
@@ -7,5 +7,5 @@ import (
 )
 
 func IsOptionWord(d prompt.Document) bool {
-	return strings.HasPrefix(d.GetWordBeforeCursor(), "-")
+	return strings.HasPrefix(d.GetWordBeforeCursor(), " -")
 }


### PR DESCRIPTION
- 直前に`-`のみではなく` -`（半角スペース追加）がある場合に限りオプションと見なすよう制御を追加
- オプションの一覧が複数ヶ所に分散されていたので集約