### PR TITLE
Feature/wsl

### DIFF
--- a/pkg/cli/opener/wsl/opener.go
+++ b/pkg/cli/opener/wsl/opener.go
@@ -1,0 +1,34 @@
+package wsl
+
+import (
+	"os/exec"
+
+	"github.com/koooyooo/soi-go/pkg/cli/opener"
+	"github.com/koooyooo/soi-go/pkg/model"
+)
+
+type wslOpener struct{}
+
+func NewOpener() opener.Opener {
+	return &wslOpener{}
+}
+
+func (o wslOpener) OpenChrome(s *model.SoiData, _ bool) error {
+	return exec.Command("cmd.exe", "/C", "start", "chrome", s.URI).Start()
+}
+
+func (o wslOpener) OpenFirefox(s *model.SoiData, private bool) error {
+	if private {
+		return exec.Command("cmd.exe", "/C", "start", "firefox", "-private-window", s.URI).Start()
+	}
+	return exec.Command("cmd.exe", "/C", "start", "firefox", s.URI).Start()
+}
+
+func (o wslOpener) OpenSafari(s *model.SoiData, _ bool) error {
+	// Safari is not available on Windows/WSL
+	return exec.Command("cmd.exe", "/C", "start", s.URI).Start()
+}
+
+func (o wslOpener) OpenEdge(s *model.SoiData, _ bool) error {
+	return exec.Command("cmd.exe", "/C", "start", "msedge", s.URI).Start()
+}

--- a/pkg/cli/soiprompt/complete/common.go
+++ b/pkg/cli/soiprompt/complete/common.go
@@ -2,11 +2,12 @@ package complete
 
 import (
 	"context"
+	"log"
+	"strings"
+
 	"github.com/c-bata/go-prompt"
 	"github.com/koooyooo/soi-go/pkg/cli/soiprompt/complete/soisort"
 	"github.com/koooyooo/soi-go/pkg/cli/soiprompt/view"
-	"log"
-	"strings"
 )
 
 func (c *Completer) baseList(d prompt.Document, commands ...string) []prompt.Suggest {
@@ -57,6 +58,7 @@ var listOptSuggests = []prompt.Suggest{
 
 func removeOption(text string) string {
 	// TODO 通常の順に並べ文字数順にソートするロジックに変更する
+	// TODO 両端にスペースを付けて引っ掛けて、半角スペースと置換する
 	var options []string
 	for _, s := range listOptSuggests {
 		options = append(options, s.Text)


### PR DESCRIPTION
This pull request introduces a new WSL (Windows Subsystem for Linux) opener and makes several improvements to the `soiprompt` package. The key changes include adding support for WSL in the opener package, reorganizing imports, and adding a utility function to detect WSL.

### WSL Support:
* [`pkg/cli/opener/wsl/opener.go`](diffhunk://#diff-a4e393e6e7d96c499e256d4a5a3f5eed0271fbb5f06bc8faa1a201089f423255R1-R34): Added a new WSL opener with methods to open Chrome, Firefox, Safari, and Edge browsers.
* [`pkg/cli/soiprompt/execute/open.go`](diffhunk://#diff-1903680cbcd2d4f42068a4cb8aad0fdbc6163435789855b6c579b9c7c53c989fR6-R16): Included the WSL opener in the `getOpener` function and added a utility function `isWSL` to detect if the environment is WSL. [[1]](diffhunk://#diff-1903680cbcd2d4f42068a4cb8aad0fdbc6163435789855b6c579b9c7c53c989fR6-R16) [[2]](diffhunk://#diff-1903680cbcd2d4f42068a4cb8aad0fdbc6163435789855b6c579b9c7c53c989fR94-R117)

### Code Reorganization:
* [`pkg/cli/soiprompt/complete/common.go`](diffhunk://#diff-e1103a03303dd8687588d694aa13bf0fe909e96b2a395378a96c7e996ad9fe03R5-L9): Reorganized import statements for better readability.

### Minor Improvements:
* [`pkg/cli/soiprompt/complete/common.go`](diffhunk://#diff-e1103a03303dd8687588d694aa13bf0fe909e96b2a395378a96c7e996ad9fe03R61): Added a comment to the `removeOption` function for future improvement.