### PR TITLE
オプションにより一部のディレクトリが不可視になる問題の修正

### DIFF
--- a/pkg/cli/soiprompt/complete/common.go
+++ b/pkg/cli/soiprompt/complete/common.go
@@ -2,6 +2,7 @@ package complete
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 
@@ -61,10 +62,10 @@ func removeOption(text string) string {
 	// TODO 両端にスペースを付けて引っ掛けて、半角スペースと置換する
 	var options []string
 	for _, s := range listOptSuggests {
-		options = append(options, s.Text)
+		options = append(options, fmt.Sprintf(" %s ", s.Text))
 	}
 	for _, opt := range options {
-		text = strings.ReplaceAll(text, opt, "")
+		text = strings.ReplaceAll(text, opt, " ")
 	}
 	return strings.TrimSpace(text)
 }


### PR DESCRIPTION
This pull request includes changes to the `pkg/cli/soiprompt/complete/common.go` file to enhance logging and improve the formatting of options in the `removeOption` function.

Improvements to logging and formatting:

* [`pkg/cli/soiprompt/complete/common.go`](diffhunk://#diff-e1103a03303dd8687588d694aa13bf0fe909e96b2a395378a96c7e996ad9fe03R5): Added the `fmt` package import to support formatted I/O operations.
* [`pkg/cli/soiprompt/complete/common.go`](diffhunk://#diff-e1103a03303dd8687588d694aa13bf0fe909e96b2a395378a96c7e996ad9fe03L64-R65): Modified the `removeOption` function to use `fmt.Sprintf` for formatting options with surrounding spaces.