### PR TITLE
Option 追加時にテキストが壊れる現象を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,15 @@ DOCKER_IMAGE_NAME=${SOI_DOCKER_IMAGE_NAME}
 run:
 	@ go run "$(CLI_MOD)"
 
-build:
+build: clean
 	@ go build -o "$(CLI_BIN)" "$(CLI_MOD)"
 
 #   go install always use "main.go"'s "main" as a binary name
-install:
+install: build
 	@ go install "$(CLI_MOD)"
 
 install-ex: install
-	@ cp ~/go/bin/soi ~/.goenv/shims/soi
+	@ cp "$(CLI_MOD)" ~/.goenv/shims/soi
 
 clean:
 	@ rm "$(CLI_BIN)"

--- a/pkg/cli/soiprompt/complete/common.go
+++ b/pkg/cli/soiprompt/complete/common.go
@@ -42,7 +42,7 @@ func (c *Completer) baseList(d prompt.Document, commands ...string) []prompt.Sug
 func removeCmd(text string, commands ...string) string {
 	text = strings.TrimSpace(text)
 	for _, cmd := range commands {
-		text = strings.TrimLeft(text, cmd+" ")
+		strings.TrimPrefix(text, cmd+" ")
 	}
 	return text
 }
@@ -62,10 +62,10 @@ func removeOption(text string) string {
 	// TODO 両端にスペースを付けて引っ掛けて、半角スペースと置換する
 	var options []string
 	for _, s := range listOptSuggests {
-		options = append(options, fmt.Sprintf(" %s ", s.Text))
+		options = append(options, s.Text)
 	}
 	for _, opt := range options {
-		text = strings.ReplaceAll(text, opt, " ")
+		text = strings.ReplaceAll(text, fmt.Sprintf(" %s ", opt), " ")
 	}
 	return strings.TrimSpace(text)
 }

--- a/pkg/cli/soiprompt/utils/option.go
+++ b/pkg/cli/soiprompt/utils/option.go
@@ -7,5 +7,5 @@ import (
 )
 
 func IsOptionWord(d prompt.Document) bool {
-	return strings.HasPrefix(d.GetWordBeforeCursor(), " -")
+	return strings.HasSuffix(d.GetWordBeforeCursor(), " -")
 }

--- a/pkg/cli/soiprompt/view/elements.go
+++ b/pkg/cli/soiprompt/view/elements.go
@@ -2,7 +2,7 @@ package view
 
 import "strings"
 
-var SigleOptions = []SingleOption{
+var SingleOptions = []SingleOption{
 	{"c", "use chrome"},
 	{"f", "use firefox"},
 	{"s", "use safari"},


### PR DESCRIPTION
This pull request includes several changes to the `Makefile` and various files in the `pkg/cli/soiprompt` directory to improve the build process and fix some issues in the code. The most important changes include adding a `clean` step to the `build` target, fixing string manipulation functions, and correcting a typo in a variable name.

### Build process improvements:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L18-R26): Added a `clean` step to the `build` target and changed the `install` target to depend on the `build` target.

### Code fixes:
* [`pkg/cli/soiprompt/complete/common.go`](diffhunk://#diff-e1103a03303dd8687588d694aa13bf0fe909e96b2a395378a96c7e996ad9fe03L45-R45): Fixed the `removeCmd` function to use `strings.TrimPrefix` instead of `strings.TrimLeft`.
* [`pkg/cli/soiprompt/complete/common.go`](diffhunk://#diff-e1103a03303dd8687588d694aa13bf0fe909e96b2a395378a96c7e996ad9fe03L65-R68): Updated the `removeOption` function to correctly format the options before replacing them in the text.
* [`pkg/cli/soiprompt/utils/option.go`](diffhunk://#diff-84f50643dcb5a9b3fa47f22760ec96f01cea09cdf8c0a1f5ecb229100903aee2L10-R10): Changed the `IsOptionWord` function to use `strings.HasSuffix` instead of `strings.HasPrefix`.
* [`pkg/cli/soiprompt/view/elements.go`](diffhunk://#diff-2bc41931003c9c2940d027c2ca2244d83da2e9360809ce28a56393f6c6d768abL5-R5): Corrected a typo in the `SingleOptions` variable name.