### PR TITLE
Opener 階層の平坦化

### DIFF
--- a/pkg/cli/opener/linux.go
+++ b/pkg/cli/opener/linux.go
@@ -1,14 +1,14 @@
-package linux
+package opener
 
 import (
-	"github.com/koooyooo/soi-go/pkg/cli/opener"
-	"github.com/koooyooo/soi-go/pkg/model"
 	"os/exec"
+
+	"github.com/koooyooo/soi-go/pkg/model"
 )
 
 type linuxOpener struct{}
 
-func NewLinuxOpener() opener.Opener {
+func NewLinuxOpener() Opener {
 	return &linuxOpener{}
 }
 

--- a/pkg/cli/opener/macos.go
+++ b/pkg/cli/opener/macos.go
@@ -1,14 +1,13 @@
-package macos
+package opener
 
 import (
 	"errors"
 	"os/exec"
 
-	"github.com/koooyooo/soi-go/pkg/cli/opener"
 	"github.com/koooyooo/soi-go/pkg/model"
 )
 
-func NewOpener() opener.Opener {
+func NewMacOpener() Opener {
 	return &macOSOpener{}
 }
 

--- a/pkg/cli/opener/windows.go
+++ b/pkg/cli/opener/windows.go
@@ -1,14 +1,13 @@
-package windows
+package opener
 
 import (
 	"errors"
 	"os/exec"
 
-	"github.com/koooyooo/soi-go/pkg/cli/opener"
 	"github.com/koooyooo/soi-go/pkg/model"
 )
 
-func NewOpener() opener.Opener {
+func NewWindowsOpener() Opener {
 	return &winOpener{}
 }
 

--- a/pkg/cli/opener/wsl.go
+++ b/pkg/cli/opener/wsl.go
@@ -1,15 +1,14 @@
-package wsl
+package opener
 
 import (
 	"os/exec"
 
-	"github.com/koooyooo/soi-go/pkg/cli/opener"
 	"github.com/koooyooo/soi-go/pkg/model"
 )
 
 type wslOpener struct{}
 
-func NewOpener() opener.Opener {
+func NewWSLOpener() Opener {
 	return &wslOpener{}
 }
 

--- a/pkg/cli/soiprompt/execute/open.go
+++ b/pkg/cli/soiprompt/execute/open.go
@@ -9,10 +9,6 @@ import (
 	"time"
 
 	"github.com/koooyooo/soi-go/pkg/cli/opener"
-	"github.com/koooyooo/soi-go/pkg/cli/opener/linux"
-	"github.com/koooyooo/soi-go/pkg/cli/opener/macos"
-	"github.com/koooyooo/soi-go/pkg/cli/opener/windows"
-	"github.com/koooyooo/soi-go/pkg/cli/opener/wsl"
 
 	"golang.org/x/net/context"
 
@@ -92,14 +88,14 @@ func (e *Executor) open(in string) error {
 func getOpener(os string) (opener.Opener, bool) {
 	switch os {
 	case "darwin":
-		return macos.NewOpener(), true
+		return opener.NewMacOpener(), true
 	case "windows":
-		return windows.NewOpener(), true
+		return opener.NewWindowsOpener(), true
 	case "linux":
 		if isWSL() {
-			return wsl.NewOpener(), true
+			return opener.NewWSLOpener(), true
 		}
-		return linux.NewLinuxOpener(), true
+		return opener.NewLinuxOpener(), true
 	}
 	return nil, false
 }


### PR DESCRIPTION
This pull request includes several changes to the `pkg/cli/opener` package, primarily focusing on renaming files and modifying package declarations to simplify the code structure. The changes also involve updating import paths and function names accordingly.

File renaming and package declaration changes:

* [`pkg/cli/opener/linux.go`](diffhunk://#diff-e2dad7c66fdf6dd17236097d62c4afd4faf26bf9d0f2691872bc11ed761c9f2cL1-R11): Renamed from `pkg/cli/opener/linux/opener.go` and changed the package declaration from `linux` to `opener`.
* [`pkg/cli/opener/macos.go`](diffhunk://#diff-60b267e9c43637e1f55fc2a26dcacee552bb8a7107d42462683b4ca530c0badfL1-R10): Renamed from `pkg/cli/opener/macos/opener.go` and changed the package declaration from `macos` to `opener`.
* [`pkg/cli/opener/windows.go`](diffhunk://#diff-eaba7c9207d3e2277187006473ee7b375a775771c2aa6c3a47ba324ce2741219L1-R10): Renamed from `pkg/cli/opener/windows/opener.go` and changed the package declaration from `windows` to `opener`.
* [`pkg/cli/opener/wsl.go`](diffhunk://#diff-0f0a54c4635f760a8c99a95af4b7ec0e7ad576cf14c13a0e8489c9d534e1b26dL1-R11): Renamed from `pkg/cli/opener/wsl/opener.go` and changed the package declaration from `wsl` to `opener`.

Import path updates:

* [`pkg/cli/soiprompt/execute/open.go`](diffhunk://#diff-1903680cbcd2d4f42068a4cb8aad0fdbc6163435789855b6c579b9c7c53c989fL12-L15): Updated import paths to reflect the new file structure and package declarations. [[1]](diffhunk://#diff-1903680cbcd2d4f42068a4cb8aad0fdbc6163435789855b6c579b9c7c53c989fL12-L15) [[2]](diffhunk://#diff-1903680cbcd2d4f42068a4cb8aad0fdbc6163435789855b6c579b9c7c53c989fL95-R98)